### PR TITLE
Notifications

### DIFF
--- a/src/js/chat.js
+++ b/src/js/chat.js
@@ -231,6 +231,7 @@ function colorizeUser ( data, uid, isAction ) {
  *  @param time: Timestamp at beginning of message
  *  @return: Formatted timestamp
  */
+function formatTime( string ) {
     // Construct date from string, get the time
     return new Date(Date.parse(string)).toTimeString().replace(/(\d{2}):(\d{2}).+/, function(match, hour, minutes) {
         // Format to non-millitary, add brackets
@@ -293,9 +294,7 @@ function postMessage( raw_msg, isHistory ) {
     postMessageScrollTriggers++;
     $("#global-chat-messages").append(message);
     if (message.includes('@' + NICK.substr(0, NICK.lastIndexOf('_') - 1))) {
-        console.log('firstIf');
         Notification.requestPermission().then(function (result) {
-            console.log(result);
             var notification = new Notification(name ? name : 'Eterna Not', {
                 body: raw_msg,
                 tag: 'eterna-chat-ping-' + message,
@@ -303,7 +302,6 @@ function postMessage( raw_msg, isHistory ) {
             });
         });
     }
-    console.log('@' + NICK.substr(0, NICK.lastIndexOf('_') - 1));
 }
 $(document).ready(function () {
     $("#disconnect").click(function () {

--- a/src/js/chat.js
+++ b/src/js/chat.js
@@ -231,7 +231,6 @@ function colorizeUser ( data, uid, isAction ) {
  *  @param time: Timestamp at beginning of message
  *  @return: Formatted timestamp
  */
-function formatTime( string ) {
     // Construct date from string, get the time
     return new Date(Date.parse(string)).toTimeString().replace(/(\d{2}):(\d{2}).+/, function(match, hour, minutes) {
         // Format to non-millitary, add brackets
@@ -293,6 +292,18 @@ function postMessage( raw_msg, isHistory ) {
         .replace("{TIME}", prefix ? formatTime(time) : '');
     postMessageScrollTriggers++;
     $("#global-chat-messages").append(message);
+    if (message.includes('@' + NICK.substr(0, NICK.lastIndexOf('_') - 1))) {
+        console.log('firstIf');
+        Notification.requestPermission().then(function (result) {
+            console.log(result);
+            var notification = new Notification(name ? name : 'Eterna Not', {
+                body: raw_msg,
+                tag: 'eterna-chat-ping-' + message,
+                icon: 'https://pbs.twimg.com/profile_images/902198585789366272/BRGnomZw.jpg'
+            });
+        });
+    }
+    console.log('@' + NICK.substr(0, NICK.lastIndexOf('_') - 1));
 }
 $(document).ready(function () {
     $("#disconnect").click(function () {


### PR DESCRIPTION
Resolves #7, #17, and #18

To Do (based and expanded on https://github.com/EteRNAgame/HTML-Chat/pull/58#issuecomment-343784185):
- [ ] Request notification permission on chat loading
  - [ ] Banner at the top of the chat (20-50px ish, full width)
    ```
    --------------------------
    Would you like to enable notifications? [      Yes     ] [      No      ]
    --------------------------
    ```
  - [ ] Dropdown on clicking "Yes"
    ```
    --------------------------
    Would you like to enable notifications? [      Yes     ] [      No      ]
    --------------------------
                                            (5-10px margin)
                                            [ All Messages ]
                                            (5-10px margin)
                                            [@mentions Only]
    ```
  - [ ] Store result in LocalStorage
  - [ ] Request notification permissions if "yes"
- [ ] Chat command: /notifications <all | mentions | off>
  - [ ] Store result in LocalStorage
  - [ ] Request notification permissions if setting to all or mentions if it has not already been granted
  - [ ] Adjust notifications to respect a change in preference
- [ ] Adjust notifications to not send or attempt to request permission for notifications if preference is `off`
- [ ] Adjust notifications to work for all messages if the preference is set to "all" 
- [ ] Use USERNAME for @mention instead of NICK
- [ ] When the current user is @mentioned, the text `@<username>` should be in a different color, maybe the light blue used on the site for mentions. Experiment with highlighting the entire message, like Discord does - if it works, use it. Otherwise, don't.
- [ ] Custom notification phrases.
    - [ ] Add chat command `/addhighlight <phrase>[, <phrase>[...]]` to specify that the specified phrase(s) should be used, and so added to localStorage
    - [ ] Add chat command `/removehighlight <*|<phrase>[, <phrase>[...]]>` to specify that the specified phrase(s) should no longer be used, and so removed from localStorage, or to remove ALL phrases when `*` is used.
    - [ ] Add chat command `/listhighlights` to list all current custom phrases being used
    - [ ] Send a notification when any of the custom phrases are used in an incoming message if the user's notification preferences are either `@mentions` or `all`
    - [ ] Change the color of the custom phrase in the message just like with @mentions
- [ ] Any @mentions should have a link to the mentioned user's profile.
- [ ] Implement autocomplete (#18) - there should be jQuery plugins and other libraries out there to do this
  - [ ] On typing @, display a dropdown of users currently in the channel
  - [ ] On typing further characters, filter the list to only include those users who have usernames that contain (case insensitive) the characters starting right after the @ sign (ie, `@Jo`, `@jo`, `@Do`, and `@oh` would all include `John Doe`, but of these only `@Do` would include `Jane Doe` as well).
  - [ ] Tab, the up and down arrow keys, and mouseovers/hovers should cycle through the names
    - [ ] The selected user should be highlighted in the dropdown
    - [ ] The selected user should replace the existing text after the @ sign where the user is typing (ie, if the user types `@Jo`, then selects `John Doe`, `@Jo` will become `@John Doe`
    - [ ] By default the top option should be selected, but this should not cause the content the user is typing to change as is described above (otherwise, there's no way for the user to type out the username they want)
  - [ ] Close the dropdown, without replacing any text, if:
    - [ ] The left or right arrow keys are usedshould dismiss the dropdown, without replacing any text
    - [ ] Somewhere outside of the dropdown (the main chat window, the input box, etc) is clicked  
    - [ ] If there are no users left in the dropdown
    - [ ] If the user hits delete until the @ sign is deleted
  - [ ] Clicking a user in the list or hitting enter should replace the text after the @ sign with the selected username plus a space, and close the dropdown
  - [ ] If the user adds or deletes characters at some point in the middle or end of a "session" of the dropdown, whether or not it was the most recent occurrence the dropdown has shown, show the dropdown again with a fresh filter. Some examples (this list may not be exhaustive) - make sure these all work (note, a space is just as invalid a character as `d` would be if it is not at that location in the name, unless otherwise specified):
    - [ ] The user types `@Johd`, and the dropdown closes due to no users including that text. The user hits backspace, changing the text to `@Joh`. `John Doe` should now be shown as a potential option.
    - [ ] The user types `@Johd`, causing the dd to close, and keeps typing. The user then hits backspace until they get to `@J`, and which point `John Doe` and `Jane Doe` would be shown.
    - [ ] The user types `@Johd`, causing the dd to close, and keeps typing (the next character **may or may not** be a space). The user then puts his cursor (via click, arrow keys, etc) after the `@Johd`, then hits backspace. The dd is then shown.
    - [ ] The user types `@Johd`, causing the dd to close, and keeps typing (the next character **may or may not** be a space). The user then puts his cursor (via click, arrow keys, etc) after the `@Jo` in `@Johd`, then deletes the o. The dd is then shown, with `John Doe` and `Jane Doe`
    - [ ] The user types `@Johd`, causing the dd to close, and keeps typing (the next character **may or may not** be a space). The user then puts his cursor (via click, arrow keys, etc) after the `@J` in `@Johd`, then types `o`. The dd is then shown, with `John Doe`.
    -  [ ] The user types `@Johd`, causing the dd to close, and keeps typing. The user then selects all the text from the final `d` in `@Johd` and some amount of text after it, then hits delete. The dd is then shown.
    - [ ] The user types `@Johd`, causing the dd to close, and keeps typing. The user then selects all the text from the final `ohd` in `@Johd` and some amount of text after it, then hits delete. The dd is then shown, including `John Doe` and `Jane Doe`
    - [ ] The user selects `John Doe`, causing the text `@John Doe` to appear in the text box and the dd to close, then **may or may not** continue typing **and/or** using other navigation (arrow keys, mouse, etc). Upon deleting the last 1 or more characters at the end of `@John Doe` (as long as the @ is not deleted), the dd should show.
    - [ ] The user types `@Joh` and then stops, and navigates away using the mouse or arrow keys. The user then navigates back to the end of the word and then deletes one or more characters (and not the @ sign). The dd should show.
    - [ ] The user types `@Joh` and then stops, and navigates away using the mouse or arrow keys. The user then navigates back to the end of the word and then types `n`. The dd should show.
    - [ ] The user types `@Johdd`, then moves the cursor after the `d` and hits delete. The dd should show.
    - [ ] The user types `@Johndd` then moves the cursor after the `o` and hits delete (`@J|hndd`). The dd should show with `John Doe` and `Jane Doe`