### PR TITLE
Fixed bug where text overflows onto send button

### DIFF
--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -107,7 +107,7 @@ textarea {
 
 /************* Chat input *************/
 #chat-input, #reconnect {    
-    width: calc(100% - 10px); 
+    width: calc(100% - 35px); 
     height: 25px;   
     resize: none;
     border: 1px solid #FFFFFF4D;
@@ -118,6 +118,7 @@ textarea {
     white-space: pre-wrap;
     word-wrap: break-word;
     outline: none;
+    padding-right:25px;
 }
 
 .chat-input-container {


### PR DESCRIPTION
Fixes bug where when a message is too long, it is obscured by the send message button. Now, the text wraps before the button and is fully visible.
